### PR TITLE
Badger folder is always needed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN apk --update add bash curl ca-certificates && update-ca-certificates
 # Install binary
 COPY --from=builder /build/go-template-linux /go-template-linux
 
+RUN mkdir -p /backend-data/badger
+
 EXPOSE 8080
 
 CMD ["/go-template-linuux", "-d"]


### PR DESCRIPTION
Since every service always uses Badger, the template always needs badger folder.